### PR TITLE
Backfill missing lab metadata (7 files)

### DIFF
--- a/Instructions/exercises/00-ai-workloads.md
+++ b/Instructions/exercises/00-ai-workloads.md
@@ -1,9 +1,10 @@
 ---
 lab:
-    title: 'Explore AI workloads'
-    description: 'See what AI can do by exploring a simple AI app.'
-    duration: 15
-    level: 100
+  title: Explore AI workloads
+  description: See what AI can do by exploring a simple AI app.
+  duration: 15
+  level: 100
+  islab: true
 ---
 
 # Explore AI workloads

--- a/Instructions/exercises/01-explore-agent.md
+++ b/Instructions/exercises/01-explore-agent.md
@@ -1,9 +1,10 @@
 ---
 lab:
-    title: 'Explore a simple AI agent'
-    description: 'Use an AI agent to chat about AI concepts.'
-    duration: 15
-    level: 100
+  title: Explore a simple AI agent
+  description: Use an AI agent to chat about AI concepts.
+  duration: 15
+  level: 100
+  islab: true
 ---
 
 # Explore a simple AI agent

--- a/Instructions/exercises/02-generative-ai.md
+++ b/Instructions/exercises/02-generative-ai.md
@@ -1,9 +1,10 @@
 ---
 lab:
-    title: 'Explore generative AI'
-    description: 'Use a chat playground to interact with a generative AI model'
-    duration: 15
-    level: 100
+  title: Explore generative AI
+  description: Use a chat playground to interact with a generative AI model
+  duration: 15
+  level: 100
+  islab: true
 ---
 
 # Explore generative AI

--- a/Instructions/exercises/03-language.md
+++ b/Instructions/exercises/03-language.md
@@ -1,9 +1,10 @@
 ---
 lab:
-    title: 'Explore AI text analysis'
-    description: 'Use AI to analyze text.'
-    duration: 15
-    level: 100
+  title: Explore AI text analysis
+  description: Use AI to analyze text.
+  duration: 15
+  level: 100
+  islab: true
 ---
 
 # Explore text analytics

--- a/Instructions/exercises/04-speech.md
+++ b/Instructions/exercises/04-speech.md
@@ -1,9 +1,11 @@
 ---
 lab:
-    title: 'Explore AI speech'
-    description: 'Use AI to explore speech-to-text and text-to-speech capabilities with a generative AI model.'
-    duration: 15
-    level: 100
+  title: Explore AI speech
+  description: Use AI to explore speech-to-text and text-to-speech capabilities with
+    a generative AI model.
+  duration: 15
+  level: 100
+  islab: true
 ---
 
 # Explore AI speech

--- a/Instructions/exercises/05-vision.md
+++ b/Instructions/exercises/05-vision.md
@@ -1,9 +1,10 @@
 ---
 lab:
-    title: 'Explore computer vision'
-    description: 'Use image analysis with a generative AI model.'
-    duration: 15
-    level: 100
+  title: Explore computer vision
+  description: Use image analysis with a generative AI model.
+  duration: 15
+  level: 100
+  islab: true
 ---
 
 # Explore computer vision

--- a/Instructions/exercises/06-info-extraction.md
+++ b/Instructions/exercises/06-info-extraction.md
@@ -1,9 +1,10 @@
 ---
 lab:
-    title: 'Explore information extraction'
-    description: 'Use OCR and generative AI to extract information from documents.'
-    duration: 15
-    level: 100
+  title: Explore information extraction
+  description: Use OCR and generative AI to extract information from documents.
+  duration: 15
+  level: 100
+  islab: true
 ---
 
 # Explore information extraction


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 7

- `Instructions/exercises/00-ai-workloads.md` (islab)
- `Instructions/exercises/01-explore-agent.md` (islab)
- `Instructions/exercises/02-generative-ai.md` (islab)
- `Instructions/exercises/03-language.md` (islab)
- `Instructions/exercises/04-speech.md` (islab)
- `Instructions/exercises/05-vision.md` (islab)
- `Instructions/exercises/06-info-extraction.md` (islab)
