### PR TITLE
Improve formatting of minimum specifications

### DIFF
--- a/Instructions/exercises/06-info-extraction.md
+++ b/Instructions/exercises/06-info-extraction.md
@@ -13,12 +13,12 @@ In this exercise, you'll use optical character recognition (OCR) and generative 
 
 To complete this lab, you need a modern browser on a computer with sufficient hardware resources to load and run the models used by the AI agent app. On older or low-spec computers, the app may run very slowly or experience errors.
 
-**Minimum spec**
-
-- 64-bit CPU, 4+ physical cores (8 logical threads preferred)
-- 8+ GB system RAM (16 GB recommended)
-- Enough storage to cache ~300MB–800MB model assets
-- Latest Chrome / Edge / Firefox (WebGPU support is required for the default model; a modelless fallback implementation is provided)
+> **Minimum spec**
+>
+> - 64-bit CPU, 4+ physical cores (8 logical threads preferred)
+> - 8+ GB system RAM (16 GB recommended)
+> - Enough storage to cache ~300MB–800MB model assets
+> - Latest Chrome / Edge / Firefox (WebGPU support is required for the default model; a modelless fallback implementation is provided)
 
 This exercise should take approximately **15** minutes to complete.
 


### PR DESCRIPTION
Updated minimum specifications formatting for clarity and consistency with the rest of the exercises (e.g. https://github.com/MicrosoftLearning/mslearn-ai-concepts/blob/main/Instructions/exercises/05-vision.md).

Addtionally, 06-info-extraction seems to be missing the point stating "GPU required for the default Phi 3.0-mini model." and the note doesn't specificy the SLM used (Phi 3.0 Mini), unlike the other exercises (e.g. 04-speech or 05-vision).